### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -205,6 +205,7 @@ module.exports = {
         useAllContextsWithNoSearchContext: true,
       },
     ],
+    "docusaurus-plugin-copy-page-button",
   ],
   stylesheets: [
     {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.49.2",
     "@mdx-js/react": "3.0.0",
     "clsx": "2.1.0",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "dompurify": "3.2.4",
     "hast-util-is-element": "3.0.0",
     "katex": "^0.16.22",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.49.2",
     "@mdx-js/react": "3.0.0",
     "clsx": "2.1.0",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "^0.5.2",
     "dompurify": "3.2.4",
     "hast-util-is-element": "3.0.0",
     "katex": "^0.16.22",


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Puffer Finance docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Puffer

The plugin is already shipping on most major DeFi/L1 docs sites: Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, and Cardano. Restaking and preconf docs are exactly the kind of content devs paste into Claude or ChatGPT to ask "what would this contract integration look like" or "explain the slashing conditions in this validator setup."

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `dependencies`
- Adds the plugin string to the end of the `plugins` array in `docusaurus.config.js`

The button auto-injects into the table-of-contents sidebar across all your docs routes (yield, puffer-preconf, institutional). No further config required, theme-aware, mobile-friendly.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button (~10k installs/month)

Happy to revert or adjust if this doesn't fit the project's direction.